### PR TITLE
Pass arguments to word_document()

### DIFF
--- a/R/redoc.R
+++ b/R/redoc.R
@@ -123,7 +123,7 @@ redoc <- function(highlight_outputs = TRUE, wrap = 80,
     keep_md = keep_md,
     pre_knit = pre_knit,
     post_processor = post_processor,
-    base_format = word_document()
+    base_format = word_document(...)
   )
   output_format
 }


### PR DESCRIPTION
The documentation said that `...` got passed to `rmarkdown::word_document()`. 

I realize that it didn't. For example, setting `reference_docx` didn't change the resulting pandoc command. 

So, I made a ground-breaking change. My job here is done. 

In all seriousness, I'm not sure if this small change will break something. 