### PR TITLE
Update mixed-workflows-with-redoc.Rmd to refer to template

### DIFF
--- a/vignettes/mixed-workflows-with-redoc.Rmd
+++ b/vignettes/mixed-workflows-with-redoc.Rmd
@@ -44,6 +44,13 @@ output: redoc::redoc
 ---
 ```
 
+The simplest way to get a working YAML header (and example document) is to
+create a new R Markdown file from the template. To do this in RStudio, select
+File > New File > R Markdown..., then in the pop-up window select *'From
+Template'* and **Reversible Microsoft Word Document** {redoc}. (Note that if you
+just installed the redoc package, you may have to restart RStudio for the
+template to appear.)
+
 `redoc()` output resembles typical R Markdown Word output, but has some key
 differences:
 


### PR DESCRIPTION
To address issue #32, added reference to redoc R Markdown template in usage vignette. 

I thought about putting something at the start of the Basic Usage section, but felt that would require greater changes to the flow of the section. Putting it in second (after the YAML header is introduced), didn't need changes to other paragraphs. Welcome feedback or other suggestions. 