### PR TITLE
BUG FIX: redoc:::assert_redoc() did not produce the expected error msg

### DIFF
--- a/R/docx-utils.R
+++ b/R/docx-utils.R
@@ -28,7 +28,7 @@ to_docx <- function(docx) {
 
 assert_redoc <- function(docx) {
   if (!is_redoc(docx)) {
-    stop(deparse(substitute(docx), " is not a reversible document"))
+    stop(deparse(substitute(docx)), " is not a reversible document")
   }
 }
 


### PR DESCRIPTION
Before:
```r
> redoc:::assert_redoc("test.docx")
Error in redoc:::assert_redoc("test.docx") : "test.docx"
In addition: Warning messages:
1: In deparse(substitute(docx), " is not a reversible document") :
  NAs introduced by coercion
2: In deparse(substitute(docx), " is not a reversible document") :
  invalid 'cutoff' value for 'deparse', using default
```

After:
```r
> redoc:::assert_redoc("test.docx")
Error in redoc:::assert_redoc("test.docx") : 
  "test.docx" is not a reversible document
```