### PR TITLE
Correctly document default of "track_changes" parameter in dedoc()

### DIFF
--- a/R/dedoc.R
+++ b/R/dedoc.R
@@ -15,7 +15,7 @@
 #'   `.docx` file. `"accept"` accepts all changes, and `"reject"` rejects all of
 #'   them. The default, `"criticmarkup"`, converts the tracked changes to
 #'   [Critic Markup syntax](http://criticmarkup.com/spec.php#thebasicsyntax).
-#'   "comments_only" will only convert comments, as other changes can be
+#'   The default, `"comments_only"` will only convert comments, as other changes can be
 #'   viewed with [redoc_diff()].
 #'   `"all"` marks up tracked changes and comments in `<span>` tags and is
 #'   useful for debugging.  See the

--- a/R/dedoc.R
+++ b/R/dedoc.R
@@ -13,7 +13,7 @@
 #'   directory
 #' @param track_changes How to deal with tracked changes and comments in the
 #'   `.docx` file. `"accept"` accepts all changes, and `"reject"` rejects all of
-#'   them. The default, `"criticmarkup"`, converts the tracked changes to
+#'   them. `"criticmarkup"`, converts the tracked changes to
 #'   [Critic Markup syntax](http://criticmarkup.com/spec.php#thebasicsyntax).
 #'   The default, `"comments_only"` will only convert comments, as other changes can be
 #'   viewed with [redoc_diff()].

--- a/man/dedoc.Rd
+++ b/man/dedoc.Rd
@@ -22,7 +22,7 @@ directory}
 \code{.docx} file. \code{"accept"} accepts all changes, and \code{"reject"} rejects all of
 them. The default, \code{"criticmarkup"}, converts the tracked changes to
 \href{http://criticmarkup.com/spec.php#thebasicsyntax}{Critic Markup syntax}.
-"comments_only" will only convert comments, as other changes can be
+The default, \code{"comments_only"} will only convert comments, as other changes can be
 viewed with \code{\link[=redoc_diff]{redoc_diff()}}.
 \code{"all"} marks up tracked changes and comments in \code{<span>} tags and is
 useful for debugging.  See the


### PR DESCRIPTION
As per #59, the documentation for dedoc() states a default different than what is the case in the code.

Closes #59 