### PR TITLE
Fix handling of UTF-8 strings on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     whoami,
     yaml,
     jsonlite,
-    sessioninfo
+    sessioninfo,
+    brio
 Suggests:
     spelling, 
     testthat,

--- a/R/dedoc.R
+++ b/R/dedoc.R
@@ -90,7 +90,7 @@ Returning markdown only. Alternate data may be provided via `orig_codefile or `o
     md <- remove_extra_newlines(md)
   }
 
-  cat(md, file = to, sep = "")
+  brio::write_lines(paste(md, collapse = ""), path = to)
   return(to)
 }
 

--- a/R/pandocoml.R
+++ b/R/pandocoml.R
@@ -11,7 +11,7 @@ md_to_openxml <- function(text, simplify = TRUE,
                           remove_bookmarks = simplify,
                           remove_secs = simplify) {
   tmpf <- tempfile(fileext = ".md")
-  cat(text, file = tmpf)
+  brio::write_lines(text, path = tmpf)
   tmpw <- tempfile(fileext = ".docx")
   pandoc_convert(tmpf, to = "docx", from = "markdown", output = tmpw)
   oml <- (

--- a/R/preprocessor.R
+++ b/R/preprocessor.R
@@ -39,7 +39,7 @@ make_preknitter <- function(wrappers = list()) {
       file_with_meta_ext(pre_knit_input, "preprocessed")
     )
     write_yaml(rmd$code, codefile)
-    brio::write_lines(rmd$text, file = preprocessed_rmd_file)
+    brio::write_lines(rmd$text, path = preprocessed_rmd_file)
     assign("knit_input", preprocessed_rmd_file, envir = render_env)
     add_intermediates(c(codefile, preprocessed_rmd_file))
   }

--- a/R/preprocessor.R
+++ b/R/preprocessor.R
@@ -39,7 +39,7 @@ make_preknitter <- function(wrappers = list()) {
       file_with_meta_ext(pre_knit_input, "preprocessed")
     )
     write_yaml(rmd$code, codefile)
-    cat(rmd$text, file = preprocessed_rmd_file)
+    brio::write_lines(rmd$text, file = preprocessed_rmd_file)
     assign("knit_input", preprocessed_rmd_file, envir = render_env)
     add_intermediates(c(codefile, preprocessed_rmd_file))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,7 @@ na_rm <- function(x) {
 }
 
 readfile <- function(x) {
-  readChar(x, file.info(x)$size)
+  brio::read_file(x)
 }
 
 file_with_meta_ext <- function(file, meta_ext, ext = tools::file_ext(file)) {


### PR DESCRIPTION
(I notice this package is in "suspended animation", but let me file this so that someone who faced this problem can find here)

I heard redoc won't work on Windows with Japanese locale (I guess this happens on the other locales as well). This is because some base R functions uses the default encoding, not UTF-8, to read/write files. This pull request is a naive solution to it, and they say this works.