### PR TITLE
Update testing framework to take arbitrary Rmds for round-tripping

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,6 +23,8 @@ tests/testthat/token_file.enc
 ^inst/endnote$
 ^tests/testthat/artifacts$
 ^testing$
-^~.+\.(docx|xlsx|pptx)$
+^.*~.+\.(docx|xlsx|pptx)$
 ^xx
 ^README\.html$
+^air\.toml$
+^\.luarc\.json$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,6 +28,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      REDOC_ARTIFACTS_DIR: "/tmp/redoc-artifacts"
 
     steps:
       - uses: actions/checkout@v4
@@ -49,3 +50,13 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+
+      - name: Upload roundtrip testing artifacts
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: ${{ format('redoc-test-docs-{0}-{1}-r{2}-{3}', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
+          path: ${{ env.REDOC_ARTIFACTS_DIR }}
+          if-no-files-found: warn
+          retention-days: 90
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ testing
 xx.*
 xx/*
 README.html
+tests/testthat/test_rmds/*.docx
 
 ### MicrosoftOffice ###
 *.tmp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,10 @@ Suggests:
     roxygen2,
     covr,
     pkgdown,
-    rstudioapi
+    rstudioapi,
+    gt
+Remotes:
+    rstudio/rmarkdown
 SystemRequirements: pandoc (>= 2.1.2) - http://pandoc.org
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat/fixtures/roundtrip.R
+++ b/tests/testthat/fixtures/roundtrip.R
@@ -1,0 +1,47 @@
+# Various functions for bootstrapping testing
+ 
+test_roundtrip <- function(test_rmd, dir = tempfile("redoc-artifacts")) {
+     
+  rmdname <- basename(tools::file_path_sans_ext(test_rmd))   
+  rmdir <- file.path(dir, rmdname)
+  ddir <- file.path(rmdir, "diffs")
+  dir.create(ddir, recursive = TRUE, showWarnings = FALSE)
+  trmd <- file.path(rmdir, basename(test_rmd))
+  file.copy(test_rmd, trmd, overwrite = TRUE)
+   
+  rmarkdown::render(
+      input = trmd,
+      output_format = redoc(),
+      output_dir = rmdir,
+      intermediates_dir = rmdir,
+      output_file = paste0(rmdname, ".docx"),
+      quiet = TRUE,
+      clean = FALSE
+   )
+
+   unzip(file.path(rmdir, paste0(rmdname, ".docx")),
+      exdir = file.path(rmdir, "docx_unzipped")
+   )
+
+  roundtrip <- file.path(rmdir, paste0(rmdname, ".roundtrip.Rmd"))
+  
+  drmd <- diffobj::diffFile(test_rmd, roundtrip,
+    mode = "sidebyside", context = "auto", format = "html",
+    tar.banner = "Original", cur.banner = "Current",
+    pager = list(file.path = tempfile(fileext = ".html"))
+  )
+   
+  cat(as.character(drmd), file = file.path(ddir, "roundtrip-rmd.html"))
+
+  orig_ast <- pandoc_ast(trmd)
+  roundtrip_ast <- pandoc_ast(roundtrip)
+  dast <- diffobj::diffObj(orig_ast, roundtrip_ast,
+    mode = "sidebyside", pager = "on", format = "html",
+    tar.banner = "Original", cur.banner = "Current"
+  )
+  cat(as.character(dast),
+    file = file.path(ddir, "roundtrip-ast.html")
+  )
+
+  rmdir
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,4 @@
+source(test_path("fixtures", "roundtrip.R"))
+dir.create(artifacts_dir <- tempfile("redoc-artifacts", tmpdir = dirname(tempdir())), recursive = TRUE)
+cli::cli_text("Run {.run {paste0('xopen::xopen(\"', artifacts_dir, '\")')}} to open the artifacts directory.")
+

--- a/tests/testthat/test_rmds/test-gt.Rmd
+++ b/tests/testthat/test_rmds/test-gt.Rmd
@@ -1,0 +1,20 @@
+---
+title: My Title
+date: Created `r Sys.Date()`
+output: redoc::redoc
+---
+
+This document tests tables in the {gt} package.
+
+```{r setup}
+library(gt)
+```
+
+```{r}
+exibble
+```
+
+```{r}
+exibble |> gt(rowname_col = "row")
+```
+


### PR DESCRIPTION
Closes #82

- Test suite now loops through Rmds in tests/testthat/rmds
- Test artifacts saved in tempdir, and uploaded as GitHub Actions artifacts